### PR TITLE
mandatoryCodingPaths implementation

### DIFF
--- a/MWWebPlugin.podspec
+++ b/MWWebPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWWebPlugin'
-    s.version               = '0.1.0'
+    s.version               = '0.1.1'
     s.summary               = 'WebView plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     WebView plugin for MobileWorkflow on iOS, containg WebView related steps:

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
@@ -27,11 +27,15 @@ public class MWWebStep: MWStep {
 }
 
 extension MWWebStep: BuildableStep {
+    
+    public static var mandatoryCodingPaths: [CodingKey] {
+        ["url"]
+    }
+    
     public static func build(stepInfo: StepInfo, services: StepServices) throws -> Step {
-        if let urlString = stepInfo.data.content["url"] as? String, let url = URL(string: urlString) {
-            return MWWebStep(identifier: stepInfo.data.identifier, url: url)
-        } else {
-            throw NSError(domain: "io.mobileworkflow.web", code: 0, userInfo: [NSLocalizedDescriptionKey:"URL missing from the JSON"])
+        guard let urlString = stepInfo.data.content["url"] as? String, let url = URL(string: urlString) else {
+            throw ParseError.invalidStepData(cause: "Missing or malformed 'url' property")
         }
+        return MWWebStep(identifier: stepInfo.data.identifier, url: url)
     }
 }


### PR DESCRIPTION
### Task

[[iOS] [Plugins] Parsing errors should show property name](https://3.basecamp.com/5245563/buckets/26145695/todos/4637867015/edit?replace=true)

### Feature/Issue

Added implementations for `static public var mandatoryCodingPaths: [CodingKey]`.

### Implementation

Adding explicit implementations rather than relying on the fallback implementation in the core's `BuildableStep` protocol.