### PR TITLE
Fixed issue where large title covers webview content

### DIFF
--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -11,6 +11,8 @@ import MobileWorkflowCore
 
 public class MWWebViewController: MWStepViewController {
     
+    public override var titleMode: StepViewControllerTitleMode { .smallTitle }
+    
     private let webView = WKWebView()
     private var webStep: MWWebStep {
         guard let webStep = self.mwStep as? MWWebStep else {
@@ -37,9 +39,7 @@ public class MWWebViewController: MWStepViewController {
     
     //MARK: Private methods
     private func setupWebView() {
-        self.webView.frame = self.view.bounds
-        self.webView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-        self.view.addSubview(self.webView)
+        self.view.addPinnedSubview(self.webView, verticalLayoutGuide: self.view.safeAreaLayoutGuide)
         self.setToolbarItems([
             UIBarButtonItem(image: UIImage(systemName: "chevron.backward"), style: .plain, target: self, action: #selector(self.navigateBack(_:))),
             UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),


### PR DESCRIPTION
### Task

[[iOS] Bug - Video preview is not shown fully in webview](https://3.basecamp.com/5245563/buckets/26145695/todos/4911307633/edit?replace=true)

### Summary

The current layout is not observing safe areas and so is covered by the large title.

### Implementation

Now pinning the webview to the main view's `safeAreaLayoutGuide`, but also setting `titleMode` to `smallTitle` as we probably don't want a large title for web view steps, So it now appears like this:

![IMG_4214B0502D77-1](https://user-images.githubusercontent.com/1300916/167149001-9fc77a15-6f40-431e-a471-c46a83d8dff3.jpeg)
