### PR TITLE
Resolve webView url against session

### DIFF
--- a/MWWebPlugin.podspec
+++ b/MWWebPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWWebPlugin'
-    s.version               = '0.1.2'
+    s.version               = '0.1.3'
     s.summary               = 'WebView plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     WebView plugin for MobileWorkflow on iOS, containg WebView related steps:

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
@@ -10,10 +10,16 @@ import MobileWorkflowCore
 
 public class MWWebStep: MWStep {
     
-    let url: URL
+    let url: String
+    let session: Session
     
-    init(identifier: String, url: URL) {
+    var resolvedUrl: URL? {
+        self.session.resolve(url: url)
+    }
+    
+    init(identifier: String, url: String, session: Session) {
         self.url = url
+        self.session = session
         super.init(identifier: identifier)
     }
     
@@ -33,9 +39,30 @@ extension MWWebStep: BuildableStep {
     }
     
     public static func build(stepInfo: StepInfo, services: StepServices) throws -> Step {
-        guard let urlString = stepInfo.data.content["url"] as? String, let url = URL(string: urlString) else {
-            throw ParseError.invalidStepData(cause: "Missing or malformed 'url' property")
+        guard let url = stepInfo.data.content["url"] as? String else {
+            throw ParseError.invalidStepData(cause: "Mandatory 'url' property not found")
         }
-        return MWWebStep(identifier: stepInfo.data.identifier, url: url)
+        return MWWebStep(identifier: stepInfo.data.identifier, url: url, session: stepInfo.session)
+    }
+}
+
+enum L10n {
+    enum WebView {
+        static let unableToResolveUrl = "Unable to resolve URL"
+    }
+}
+
+public enum WebViewError: LocalizedError {
+    case unableToResolveURL
+    
+    public var errorDescription: String? {
+        return self.description
+    }
+    
+    public var description: String {
+        switch self {
+        case .unableToResolveURL:
+            return L10n.WebView.unableToResolveUrl
+        }
     }
 }

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -24,7 +24,7 @@ public class MWWebViewController: MWStepViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         self.setupWebView()
-        self.load(url: self.webStep.url)
+        self.resolveUrlAndLoad()
     }
     
     public override func viewWillAppear(_ animated: Bool) {
@@ -51,6 +51,14 @@ public class MWWebViewController: MWStepViewController {
         ], animated: false)
     }
     
+    private func resolveUrlAndLoad() {
+        if let resolvedUrl = self.webStep.resolvedUrl {
+            self.load(url: resolvedUrl)
+        } else {
+            self.show(WebViewError.unableToResolveURL)
+        }
+    }
+    
     private func load(url: URL) {
         let request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 60)
         self.webView.load(request)
@@ -70,17 +78,14 @@ public class MWWebViewController: MWStepViewController {
     }
     
     @IBAction private func reloadCurrentPageOrOriginal(_ sender: UIBarButtonItem) {
-        let urlToReload: URL
         if let currentUrl = self.webView.url {
-            urlToReload = currentUrl
+            self.load(url: currentUrl)
         } else {
-            urlToReload = self.webStep.url
+            self.resolveUrlAndLoad()
         }
-        self.load(url: urlToReload)
     }
     
     @IBAction private func continueToNextStep(_ sender: UIBarButtonItem) {
         self.goForward()
     }
-    
 }


### PR DESCRIPTION
### Task

[[iOS] [Android] Dynamic URLs are not working for web view step](https://3.basecamp.com/5245563/buckets/26145695/todos/4866450512/edit?replace=true)

### Summary

Add session resolution to the url provided to the webview step.

### Implementation

The url is now resolved against the session on each load of the webview, and an alert is shown if the resolution fails.