### PR TITLE
[iOS][Android] [WebView] Add a flag to hide navigation bar and items

### DIFF
--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
@@ -11,6 +11,7 @@ import MobileWorkflowCore
 public class MWWebStep: MWStep {
     
     let url: String
+    let hideNavigation: Bool
     let session: Session
     let services: StepServices
     
@@ -18,10 +19,11 @@ public class MWWebStep: MWStep {
         self.session.resolve(url: url)
     }
     
-    init(identifier: String, url: String, session: Session, services: StepServices) {
+    init(identifier: String, url: String, hideNavigation: Bool, session: Session, services: StepServices) {
         self.url = url
         self.session = session
         self.services = services
+        self.hideNavigation = hideNavigation
         super.init(identifier: identifier)
     }
     
@@ -48,7 +50,8 @@ extension MWWebStep: BuildableStep {
         guard let url = stepInfo.data.content["url"] as? String else {
             throw ParseError.invalidStepData(cause: "Mandatory 'url' property not found")
         }
-        return MWWebStep(identifier: stepInfo.data.identifier, url: url, session: stepInfo.session, services: services)
+        let hideNavigation = stepInfo.data.content["hideNavigation"] as? Bool ?? false
+        return MWWebStep(identifier: stepInfo.data.identifier, url: url, hideNavigation: hideNavigation, session: stepInfo.session, services: services)
     }
 }
 

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
@@ -12,14 +12,16 @@ public class MWWebStep: MWStep {
     
     let url: String
     let session: Session
+    let services: StepServices
     
     var resolvedUrl: URL? {
         self.session.resolve(url: url)
     }
     
-    init(identifier: String, url: String, session: Session) {
+    init(identifier: String, url: String, session: Session, services: StepServices) {
         self.url = url
         self.session = session
+        self.services = services
         super.init(identifier: identifier)
     }
     
@@ -29,6 +31,10 @@ public class MWWebStep: MWStep {
     
     public override func instantiateViewController() -> StepViewController {
         MWWebViewController(step: self)
+    }
+    
+    public func translate(text: String) -> String {
+        return self.services.localizationService.translate(text) ?? text
     }
 }
 
@@ -42,7 +48,7 @@ extension MWWebStep: BuildableStep {
         guard let url = stepInfo.data.content["url"] as? String else {
             throw ParseError.invalidStepData(cause: "Mandatory 'url' property not found")
         }
-        return MWWebStep(identifier: stepInfo.data.identifier, url: url, session: stepInfo.session)
+        return MWWebStep(identifier: stepInfo.data.identifier, url: url, session: stepInfo.session, services: services)
     }
 }
 

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -20,6 +20,9 @@ public class MWWebViewController: MWStepViewController {
         }
         return webStep
     }
+    private var showToolbar: Bool {
+        self.hasNextStep() || !self.webStep.hideNavigation
+    }
     
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -29,26 +32,55 @@ public class MWWebViewController: MWStepViewController {
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.navigationController?.setToolbarHidden(false, animated: animated)
+        if (self.showToolbar) {
+            self.navigationController?.setToolbarHidden(false, animated: animated)
+        }
     }
     
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        self.navigationController?.setToolbarHidden(true, animated: animated)
+        if (self.showToolbar) {
+            self.navigationController?.setToolbarHidden(true, animated: animated)
+        }
     }
     
     //MARK: Private methods
     private func setupWebView() {
         self.view.addPinnedSubview(self.webView, verticalLayoutGuide: self.view.safeAreaLayoutGuide)
-        self.setToolbarItems([
-            UIBarButtonItem(image: UIImage(systemName: "chevron.backward"), style: .plain, target: self, action: #selector(self.navigateBack(_:))),
-            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-            UIBarButtonItem(image: UIImage(systemName: "chevron.forward"), style: .plain, target: self, action: #selector(self.navigateForward(_:))),
-            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-            UIBarButtonItem(image: UIImage(systemName: "arrow.clockwise"), style: .plain, target: self, action: #selector(self.reloadCurrentPageOrOriginal(_:))),
-            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-            UIBarButtonItem(title: self.webStep.translate(text: "Continue"), style: .done, target: self, action: #selector(self.continueToNextStep(_:)))
-        ], animated: false)
+        
+        let items: [UIBarButtonItem]
+        let continueButton = UIBarButtonItem(title: self.webStep.translate(text: "Continue"), style: .done, target: self, action: #selector(self.continueToNextStep(_:)))
+        let backwards = UIBarButtonItem(image: UIImage(systemName: "chevron.backward"), style: .plain, target: self, action: #selector(self.navigateBack(_:)))
+        let forwards = UIBarButtonItem(image: UIImage(systemName: "chevron.forward"), style: .plain, target: self, action: #selector(self.navigateForward(_:)))
+        let reload = UIBarButtonItem(image: UIImage(systemName: "arrow.clockwise"), style: .plain, target: self, action: #selector(self.reloadCurrentPageOrOriginal(_:)))
+
+        
+        switch (self.webStep.hideNavigation, self.hasNextStep()) {
+        case (true, true):
+            items = [UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil), continueButton]
+        case (true, false):
+            items = []
+        case (false, true):
+            items = [
+                backwards,
+                UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+                forwards,
+                UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+                reload,
+                UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+                continueButton
+            ]
+        case (false, false):
+            items = [
+                backwards,
+                UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+                forwards,
+                UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+                reload
+            ]
+        }
+        
+        self.setToolbarItems(items, animated: false)
     }
     
     private func resolveUrlAndLoad() {

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -47,7 +47,7 @@ public class MWWebViewController: MWStepViewController {
             UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
             UIBarButtonItem(image: UIImage(systemName: "arrow.clockwise"), style: .plain, target: self, action: #selector(self.reloadCurrentPageOrOriginal(_:))),
             UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-            UIBarButtonItem(title: "Continue", style: .done, target: self, action: #selector(self.continueToNextStep(_:)))
+            UIBarButtonItem(title: self.webStep.translate(text: "Continue"), style: .done, target: self, action: #selector(self.continueToNextStep(_:)))
         ], animated: false)
     }
     


### PR DESCRIPTION
### Task

[[iOS][Android] [WebView] Add a flag to hide navigation bar and items](https://3.basecamp.com/5245563/buckets/26145695/todos/5238416060)

### Feature/Issue

The user should be able to hide the toolbar navigation if needed/wanted.

### Implementation

The new `hideNavigation` property was added to the webview step and it is used to configure the toolbar. If the step hides the toolbar and is the last step, the toolbar is no longer presented. If the Webview Step is not the last step, the "continue" action is still added to the toolbar so the app user can navigate next.

### UI demonstration

https://user-images.githubusercontent.com/2117340/185459576-c24815e7-0557-4831-a088-2be275dcddb6.MP4
