### PR TITLE
Update navigation when toolbar hidden

### DIFF
--- a/MWWebPlugin.podspec
+++ b/MWWebPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWWebPlugin'
-    s.version               = '0.1.5'
+    s.version               = '0.1.6'
     s.summary               = 'WebView plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     WebView plugin for MobileWorkflow on iOS, containg WebView related steps:

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -24,9 +24,6 @@ public class MWWebViewController: MWStepViewController {
     private var hideNavigation: Bool {
         return self.webStep.hideNavigation
     }
-    private var showToolbar: Bool {
-        self.hasNextStep() || !self.webStep.hideNavigation
-    }
     
     public override func viewDidLoad() {
         super.viewDidLoad()

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -12,6 +12,7 @@ import MobileWorkflowCore
 public class MWWebViewController: MWStepViewController {
     
     public override var titleMode: StepViewControllerTitleMode { .smallTitle }
+    lazy var continueButton = UIBarButtonItem(title: self.webStep.translate(text: "Next"), style: .done, target: self, action: #selector(self.continueToNextStep(_:)))
     
     private let webView = WKWebView()
     private var webStep: MWWebStep {
@@ -19,6 +20,9 @@ public class MWWebViewController: MWStepViewController {
             preconditionFailure("Unexpected step type. Expecting \(String(describing: MWWebStep.self)), got \(String(describing: type(of: self.mwStep)))")
         }
         return webStep
+    }
+    private var hideNavigation: Bool {
+        return self.webStep.hideNavigation
     }
     private var showToolbar: Bool {
         self.hasNextStep() || !self.webStep.hideNavigation
@@ -32,14 +36,16 @@ public class MWWebViewController: MWStepViewController {
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        if (self.showToolbar) {
+        if (!self.hideNavigation) {
             self.navigationController?.setToolbarHidden(false, animated: animated)
+        } else {
+            self.configureNavigationBar()
         }
     }
     
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        if (self.showToolbar) {
+        if (!self.hideNavigation) {
             self.navigationController?.setToolbarHidden(true, animated: animated)
         }
     }
@@ -48,19 +54,24 @@ public class MWWebViewController: MWStepViewController {
     private func setupWebView() {
         self.view.addPinnedSubview(self.webView, verticalLayoutGuide: self.view.safeAreaLayoutGuide)
         
-        let items: [UIBarButtonItem]
-        let continueButton = UIBarButtonItem(title: self.webStep.translate(text: "Continue"), style: .done, target: self, action: #selector(self.continueToNextStep(_:)))
+        if (!self.hideNavigation) {
+            self.configureToolbar()
+        }
+    }
+    
+    private func configureNavigationBar() {
+        let nextButtonToShow = self.hasNextStep() ? self.continueButton : nil
+        self.navigationItem.rightBarButtonItems = [self.cancelButtonItem, self.utilityButtonItem, nextButtonToShow].compactMap { $0 }
+    }
+    
+    private func configureToolbar() {
         let backwards = UIBarButtonItem(image: UIImage(systemName: "chevron.backward"), style: .plain, target: self, action: #selector(self.navigateBack(_:)))
         let forwards = UIBarButtonItem(image: UIImage(systemName: "chevron.forward"), style: .plain, target: self, action: #selector(self.navigateForward(_:)))
         let reload = UIBarButtonItem(image: UIImage(systemName: "arrow.clockwise"), style: .plain, target: self, action: #selector(self.reloadCurrentPageOrOriginal(_:)))
-
         
-        switch (self.webStep.hideNavigation, self.hasNextStep()) {
-        case (true, true):
-            items = [UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil), continueButton]
-        case (true, false):
-            items = []
-        case (false, true):
+        let items: [UIBarButtonItem]
+        
+        if (self.hasNextStep()) {
             items = [
                 backwards,
                 UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
@@ -68,9 +79,9 @@ public class MWWebViewController: MWStepViewController {
                 UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
                 reload,
                 UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-                continueButton
+                self.continueButton
             ]
-        case (false, false):
+        } else {
             items = [
                 backwards,
                 UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
@@ -80,7 +91,7 @@ public class MWWebViewController: MWStepViewController {
             ]
         }
         
-        self.setToolbarItems(items, animated: false)
+        self.setToolbarItems(items, animated: true)
     }
     
     private func resolveUrlAndLoad() {


### PR DESCRIPTION
### Task

[[iOS][Android] [WebView] Add a flag to hide navigation bar and items](https://3.basecamp.com/5245563/buckets/26145695/todos/5238416060#__recording_5244545560)

### Feature/Issue

Update the next action to match the logic:

> [...] if the hide navigation toolbar flag is true
>
> 1) continue button goes in navbar
> 2) if there is no next step continue button is hidden
> 3) the toolbar is removed

### Implementation

The "Continue" was renamed to "Next" and, based on the hide navigation property, the step either set up a toolbar or a navigation bar. The existence/show of the next button is based on the `hasNextStep` of the controller.

### Demonstration

**Push navigation**

https://user-images.githubusercontent.com/2117340/185603186-4f2b1b39-85a6-4f46-9871-6773c63094fd.mp4

**Modal presentation**

https://user-images.githubusercontent.com/2117340/185603209-12de9dea-f4fd-45e4-ba2d-10b210ada3e3.mp4