### PR TITLE
Allow web page to request camera and sensor permissions

### DIFF
--- a/MWWebPlugin.podspec
+++ b/MWWebPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWWebPlugin'
-    s.version               = '0.2.0'
+    s.version               = '0.2.1'
     s.summary               = 'WebView plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     WebView plugin for MobileWorkflow on iOS, containg WebView related steps:

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -54,6 +54,7 @@ public class MWWebViewController: MWStepViewController {
         if (!self.hideNavigation) {
             self.configureToolbar()
         }
+        self.webView.uiDelegate = self
     }
     
     private func configureNavigationBar() {
@@ -127,5 +128,16 @@ public class MWWebViewController: MWStepViewController {
     
     @IBAction private func continueToNextStep(_ sender: UIBarButtonItem) {
         self.goForward()
+    }
+}
+
+extension MWWebViewController: WKUIDelegate {
+    public func webView(_ webView: WKWebView, decideMediaCapturePermissionsFor origin: WKSecurityOrigin, initiatedBy frame: WKFrameInfo, type: WKMediaCaptureType) async -> WKPermissionDecision {
+        return .prompt
+    }
+    
+    // WebKit doesn't provide async counterpart for this delegate
+    public func webView(_ webView: WKWebView, requestDeviceOrientationAndMotionPermissionFor origin: WKSecurityOrigin, initiatedByFrame frame: WKFrameInfo, decisionHandler: @escaping (WKPermissionDecision) -> Void) {
+        decisionHandler(.prompt)
     }
 }


### PR DESCRIPTION
<!-- TITLE OF THE PR: For the title, if there is an associated task/todo/pitch, please create the PR with the task name. Example: [iOS] Empty view behaviour -->

### Task

<!-- Please, add here links to the task/pitch/todo/thread that triggered this Pull Request. Example: [[iOS] Empty view behaviour](https://3.basecamp.com/5245563/buckets/26145695/todos/4882286741) -->

[[iOS] [Android] Build app with WebView plugin to add Aircards links](https://3.basecamp.com/5245563/buckets/29451097/todos/5359951913)

### Feature/Issue

<!-- Please describe in short terms what is the scope of the feature or what is the bug that is being fixed -->

In order to allow AR experiences within the web view, the web page needs access to the camera and sensor data.
This change prompts the user for the permissions.

### Implementation

<!-- Please describe the general idea of what was implemented. Comments that may help your peer reviewer. Things like: architectural details, points of attention, etc. -->

Implements `WKUIDelegate` and the required functions that enable the functionality.



https://user-images.githubusercontent.com/605861/192547713-729aca88-f02b-41dd-bd9e-1753f784369d.mp4



### Notes

<!-- If there is any test step, or consideration about the feature, please, add it here. This may include prints/videos of the feature in action. -->

One of the delegate functions doesn't have an `async` counterpart.