### PR TITLE
[iOS] [Android] WebView - Progress Indicator

### DIFF
--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -17,12 +17,14 @@ public class MWWebViewController: MWStepViewController {
     
     private lazy var webView = {
         let webView = WKWebView()
+        webView.translatesAutoresizingMaskIntoConstraints = false
         webView.navigationDelegate = self
         webView.uiDelegate = self
         return webView
     }()
     private lazy var loadingIndicator: UIActivityIndicatorView = {
         let loadingIndicator = UIActivityIndicatorView(style: .large)
+        loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
         loadingIndicator.hidesWhenStopped = true
         return loadingIndicator
     }()
@@ -38,8 +40,8 @@ public class MWWebViewController: MWStepViewController {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
-        self.setupLoadingIndicator()
         self.setupWebView()
+        self.setupLoadingIndicator()
         self.resolveUrlAndLoad()
     }
     
@@ -153,15 +155,11 @@ public class MWWebViewController: MWStepViewController {
 extension MWWebViewController {
     @MainActor
     private func showLoading() {
-        if (self.loadingIndicator.isAnimating) { return }
-        self.webView.isHidden = true
         self.loadingIndicator.startAnimating()
     }
     
     @MainActor
     private func hideLoading() {
-        if (!self.loadingIndicator.isAnimating) { return }
-        self.webView.isHidden = false
         self.loadingIndicator.stopAnimating()
     }
 }

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -8,6 +8,7 @@
 import WebKit
 import Foundation
 import MobileWorkflowCore
+import UIKit
 
 public class MWWebViewController: MWStepViewController {
     
@@ -19,6 +20,11 @@ public class MWWebViewController: MWStepViewController {
         webView.navigationDelegate = self
         webView.uiDelegate = self
         return webView
+    }()
+    private lazy var loadingIndicator: UIActivityIndicatorView = {
+        let loadingIndicator = UIActivityIndicatorView(style: .large)
+        loadingIndicator.hidesWhenStopped = true
+        return loadingIndicator
     }()
     private var webStep: MWWebStep {
         guard let webStep = self.mwStep as? MWWebStep else {
@@ -32,6 +38,7 @@ public class MWWebViewController: MWStepViewController {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
+        self.setupLoadingIndicator()
         self.setupWebView()
         self.resolveUrlAndLoad()
     }
@@ -53,6 +60,13 @@ public class MWWebViewController: MWStepViewController {
     }
     
     //MARK: Private methods
+    private func setupLoadingIndicator() {
+        self.view.addSubview(self.loadingIndicator)
+        NSLayoutConstraint.activate([
+            self.loadingIndicator.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
+            self.loadingIndicator.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
+        ])
+    }
     private func setupWebView() {
         self.view.addPinnedSubview(self.webView, verticalLayoutGuide: self.view.safeAreaLayoutGuide)
         
@@ -139,12 +153,16 @@ public class MWWebViewController: MWStepViewController {
 extension MWWebViewController {
     @MainActor
     private func showLoading() {
-        
+        if (self.loadingIndicator.isAnimating) { return }
+        self.webView.isHidden = true
+        self.loadingIndicator.startAnimating()
     }
     
     @MainActor
     private func hideLoading() {
-        
+        if (!self.loadingIndicator.isAnimating) { return }
+        self.webView.isHidden = false
+        self.loadingIndicator.stopAnimating()
     }
 }
 

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -155,11 +155,15 @@ public class MWWebViewController: MWStepViewController {
 extension MWWebViewController {
     @MainActor
     private func showLoading() {
+        if (self.loadingIndicator.isAnimating) { return }
+        self.webView.isHidden = true
         self.loadingIndicator.startAnimating()
     }
     
     @MainActor
     private func hideLoading() {
+        if (!self.loadingIndicator.isAnimating) { return }
+        self.webView.isHidden = false
         self.loadingIndicator.stopAnimating()
     }
 }


### PR DESCRIPTION
### Task

[[iOS] [Android] WebView - Progress Indicator](https://3.basecamp.com/5245563/buckets/26145695/todos/5391055681)

### Feature

Show a progress indicator while the page is being loaded, to better indicate to the user that something is happening on the screen

### Implementation

Include an UIActivityIndicatorView into the MWWebViewController and hide/show it as necessary. To ensure that the item can be rendered, the web view is hidden while the indicator is animating.

### Example


https://user-images.githubusercontent.com/2117340/194564797-4c6a3c1c-81dc-41f8-a156-1f27a7a7a2e0.MP4