### PR TITLE
[iOS] [Android] Option to hide top nav bar from webview step

### DIFF
--- a/MWWebPlugin.podspec
+++ b/MWWebPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWWebPlugin'
-    s.version               = '0.2.2'
+    s.version               = '0.2.3'
     s.summary               = 'WebView plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     WebView plugin for MobileWorkflow on iOS, containg WebView related steps:

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
@@ -12,6 +12,7 @@ public class MWWebStep: MWStep {
     
     let url: String
     let hideNavigation: Bool
+    let hideNavigationBar: Bool
     let session: Session
     let services: StepServices
     
@@ -19,11 +20,12 @@ public class MWWebStep: MWStep {
         self.session.resolve(url: url)
     }
     
-    init(identifier: String, url: String, hideNavigation: Bool, session: Session, services: StepServices) {
+    init(identifier: String, url: String, hideNavigation: Bool, hideNavigationBar: Bool, session: Session, services: StepServices) {
         self.url = url
         self.session = session
         self.services = services
         self.hideNavigation = hideNavigation
+        self.hideNavigationBar = hideNavigationBar
         super.init(identifier: identifier)
     }
     
@@ -51,7 +53,8 @@ extension MWWebStep: BuildableStep {
             throw ParseError.invalidStepData(cause: "Mandatory 'url' property not found")
         }
         let hideNavigation = stepInfo.data.content["hideNavigation"] as? Bool ?? false
-        return MWWebStep(identifier: stepInfo.data.identifier, url: url, hideNavigation: hideNavigation, session: stepInfo.session, services: services)
+        let hideNavigationBar = stepInfo.data.content["hideTopNavigationBar"] as? Bool ?? false
+        return MWWebStep(identifier: stepInfo.data.identifier, url: url, hideNavigation: hideNavigation, hideNavigationBar: hideNavigationBar, session: stepInfo.session, services: services)
     }
 }
 

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -37,6 +37,9 @@ public class MWWebViewController: MWStepViewController {
     private var hideNavigation: Bool {
         return self.webStep.hideNavigation
     }
+    private var hideNavigationBar: Bool {
+        return self.webStep.hideNavigationBar
+    }
     
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -52,12 +55,18 @@ public class MWWebViewController: MWStepViewController {
         } else {
             self.configureNavigationBar()
         }
+        if (self.hideNavigationBar) {
+            self.navigationController?.setNavigationBarHidden(true, animated: animated)
+        }
     }
     
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         if (!self.hideNavigation) {
             self.navigationController?.setToolbarHidden(true, animated: animated)
+        }
+        if (self.hideNavigationBar) {
+            self.navigationController?.setNavigationBarHidden(false, animated: animated)
         }
     }
     


### PR DESCRIPTION
### Task

[[iOS] [Android] Option to hide top nav bar from webview step](https://3.basecamp.com/5245563/buckets/26145695/todos/5582182281)

### Feature/Issue

Give to the user the possibility of hiding the Navigation Bar on a Webview Step

### Implementation

Receives the new option on the step and uses it to hide/show the Navigation Bar during view willAppear/willDisappear methods.

### Note

If the user hides the Navigation Bar, the back button will be hidden as well and the user will not be able to perform a swipe gesture to navigate back.

### Demonstration

https://user-images.githubusercontent.com/2117340/204354180-67700f2a-f1a9-459b-a964-568b76a0880b.mp4