### PR TITLE
Fix bug for: [iOS] [Android] Option to hide top nav bar from webview step

### DIFF
--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -41,11 +41,6 @@ public class MWWebViewController: MWStepViewController {
         return self.webStep.hideNavigationBar
     }
     
-    public override var restorNavigationBarOnAppear: Bool {
-        get { !self.webStep.hideNavigationBar }
-        set {}
-    }
-    
     public override func viewDidLoad() {
         super.viewDidLoad()
         self.setupWebView()
@@ -88,6 +83,12 @@ public class MWWebViewController: MWStepViewController {
         
         if (!self.hideNavigation) {
             self.configureToolbar()
+        }
+    }
+    
+    public override func configureNavigationBar(_ navigationBar: UINavigationBar) {
+        if (!self.hideNavigationBar) {
+            super.configureNavigationBar(navigationBar)
         }
     }
     

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -41,6 +41,11 @@ public class MWWebViewController: MWStepViewController {
         return self.webStep.hideNavigationBar
     }
     
+    public override var restorNavigationBarOnAppear: Bool {
+        get { !self.webStep.hideNavigationBar }
+        set {}
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         self.setupWebView()
@@ -83,12 +88,6 @@ public class MWWebViewController: MWStepViewController {
         
         if (!self.hideNavigation) {
             self.configureToolbar()
-        }
-    }
-    
-    public override func configureNavigationBar(_ navigationBar: UINavigationBar) {
-        if (!self.hideNavigationBar) {
-            super.configureNavigationBar(navigationBar)
         }
     }
     

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -53,7 +53,7 @@ public class MWWebViewController: MWStepViewController {
         if (!self.hideNavigation) {
             self.navigationController?.setToolbarHidden(false, animated: animated)
         } else {
-            self.configureNavigationBar()
+            self.configureNavigationBarActions()
         }
         if (self.hideNavigationBar) {
             self.navigationController?.setNavigationBarHidden(true, animated: animated)
@@ -86,7 +86,13 @@ public class MWWebViewController: MWStepViewController {
         }
     }
     
-    private func configureNavigationBar() {
+    public override func configureNavigationBar(_ navigationBar: UINavigationBar) {
+        if (!self.hideNavigationBar) {
+            super.configureNavigationBar(navigationBar)
+        }
+    }
+    
+    private func configureNavigationBarActions() {
         let nextButtonToShow = self.hasNextStep() ? self.continueButton : nil
         self.navigationItem.rightBarButtonItems = [self.cancelButtonItem, self.utilityButtonItem, nextButtonToShow].compactMap { $0 }
     }


### PR DESCRIPTION
### Task

[[iOS] [Android] Option to hide top nav bar from webview step](https://3.basecamp.com/5245563/buckets/26145695/todos/5582182281)

### Feature/Issue

If the user goes out of the app and back in, the app restores that Navigation Bar, which shouldn't be true for the WebView plugin. Example:

https://user-images.githubusercontent.com/2117340/204785774-e58e43d1-940a-4c05-8888-9d232053618f.mov

### Implementation

@FWJonathan As you commented on PR #12, the logic to apply the theme to a navigation bar introduces complications.

I thought about adding a variable `restoreNavigationBarOnAppear` to the step that a plugin developer can override/set to have control over this behaviour, but this would block the release of this plugin's new version until a new core version was released.

To avoid release deadlock with the core, I overwrote the `configureNavigationBar(_:)` method at the WebView step to skip if the navigation bar should be hidden.

### Demonstration

https://user-images.githubusercontent.com/2117340/204786946-d9c63bb7-0ff6-447b-8770-e0ccf18bafce.mov
