### PR TITLE
Add Share Button to Web step

### DIFF
--- a/MWWebPlugin.podspec
+++ b/MWWebPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWWebPlugin'
-    s.version               = '0.2.3'
+    s.version               = '0.3.0'
     s.summary               = 'WebView plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     WebView plugin for MobileWorkflow on iOS, containg WebView related steps:

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
@@ -13,6 +13,7 @@ public class MWWebStep: MWStep {
     let url: String
     let hideNavigation: Bool
     let hideNavigationBar: Bool
+    let sharingEnabled: Bool
     let session: Session
     let services: StepServices
     
@@ -20,12 +21,19 @@ public class MWWebStep: MWStep {
         self.session.resolve(url: url)
     }
     
-    init(identifier: String, url: String, hideNavigation: Bool, hideNavigationBar: Bool, session: Session, services: StepServices) {
+    init(identifier: String,
+         url: String,
+         hideNavigation: Bool,
+         hideNavigationBar: Bool,
+         sharingEnabled: Bool,
+         session: Session,
+         services: StepServices) {
         self.url = url
         self.session = session
         self.services = services
         self.hideNavigation = hideNavigation
         self.hideNavigationBar = hideNavigationBar
+        self.sharingEnabled = sharingEnabled
         super.init(identifier: identifier)
     }
     
@@ -54,7 +62,14 @@ extension MWWebStep: BuildableStep {
         }
         let hideNavigation = stepInfo.data.content["hideNavigation"] as? Bool ?? false
         let hideNavigationBar = stepInfo.data.content["hideTopNavigationBar"] as? Bool ?? false
-        return MWWebStep(identifier: stepInfo.data.identifier, url: url, hideNavigation: hideNavigation, hideNavigationBar: hideNavigationBar, session: stepInfo.session, services: services)
+        let sharingEnabled = stepInfo.data.content["sharingEnabled"] as? Bool ?? false
+        return MWWebStep(identifier: stepInfo.data.identifier,
+                         url: url,
+                         hideNavigation: hideNavigation,
+                         hideNavigationBar: hideNavigationBar,
+                         sharingEnabled: sharingEnabled,
+                         session: stepInfo.session,
+                         services: services)
     }
 }
 


### PR DESCRIPTION
<!-- TITLE OF THE PR: For the title, if there is an associated task/todo/pitch, please create the PR with the task name. Example: [iOS] Empty view behaviour -->

### Task

<!-- Please, add here links to the task/pitch/todo/thread that triggered this Pull Request. Example: [[iOS] Empty view behaviour](https://3.basecamp.com/5245563/buckets/26145695/todos/4882286741) -->
[[iOS][Android] Add Share Button to Web step](https://3.basecamp.com/5245563/buckets/26145695/todos/5900337702)

### Feature/Issue

<!-- Please describe in short terms what is the scope of the feature or what is the bug that is being fixed -->
Add a share button functionality to the web view.

### Implementation

<!-- Please describe the general idea of what was implemented. Comments that may help your peer reviewer. Things like: architectural details, points of attention, etc. -->
Adds share button to toolbar, if not hidden.
If toolbar is hidden, it is added to the navigation bar using `MWStepViewController.utilityButtonItem`.

![IMG_1016](https://user-images.githubusercontent.com/605861/223977377-83033f2d-a4e3-4eec-a390-4bde454a2615.PNG)
![IMG_1017](https://user-images.githubusercontent.com/605861/223977392-a5a9c0f4-8215-4d57-8c39-ebf42069962f.PNG)


### Notes

<!-- If there is any test step, or consideration about the feature, please, add it here. This may include prints/videos of the feature in action. -->