### PR TITLE
Create concept of remote action and Rest WebView

### DIFF
--- a/MWWebPlugin.podspec
+++ b/MWWebPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWWebPlugin'
-    s.version               = '0.3.2'
+    s.version               = '0.4.0'
     s.summary               = 'WebView plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     WebView plugin for MobileWorkflow on iOS, containg WebView related steps:

--- a/MWWebPlugin/MWWebPlugin/MWWebPluginStruct.swift
+++ b/MWWebPlugin/MWWebPlugin/MWWebPluginStruct.swift
@@ -17,6 +17,7 @@ public struct MWWebPluginStruct: Plugin {
 public enum MWWebStepType: String, StepType, CaseIterable {
     
     case web = "io.mobileworkflow.WebView"
+    case restWeb = "io.app-rail.webview.rest-web-view"
     
     public var typeName: String {
         return self.rawValue
@@ -25,6 +26,7 @@ public enum MWWebStepType: String, StepType, CaseIterable {
     public var stepClass: BuildableStep.Type {
         switch self {
         case .web: return MWWebStep.self
+        case .restWeb: return RestWebViewStep.self
         }
     }
 }

--- a/MWWebPlugin/MWWebPlugin/RestWebStep/RestWebViewStep.swift
+++ b/MWWebPlugin/MWWebPlugin/RestWebStep/RestWebViewStep.swift
@@ -67,6 +67,11 @@ public class RestWebViewStep: ObservableStep, BuildableStepWithMetadata {
 }
 
 extension RestWebViewStep: WebStepConfiguration {
+    public func preloadConfiguration() async throws -> Bool {
+        //TODO: Reload configuration
+        return true
+    }
+    
     public var hideNavigation: Bool {
         configuration?.hideNavigation ?? true
     }

--- a/MWWebPlugin/MWWebPlugin/RestWebStep/RestWebViewStep.swift
+++ b/MWWebPlugin/MWWebPlugin/RestWebStep/RestWebViewStep.swift
@@ -1,0 +1,94 @@
+//
+//  RestWebViewStep.swift
+//  WebViewPlugin
+//
+//
+
+import Foundation
+import MobileWorkflowCore
+
+
+// MARK: - Step properties configuration
+public class WebViewRestWebViewMetadata: StepMetadata {
+    enum CodingKeys: String, CodingKey {
+        case url
+    }
+    
+    let url: String
+    
+    init(id: String, title: String, url: String, next: PushLinkMetadata?, links: [LinkMetadata]) {
+        self.url = url
+        super.init(id: id, type: "io.app-rail.webview.rest-web-view", title: title, next: next, links: links)
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.url = try container.decode(String.self, forKey: .url)
+        try super.init(from: decoder)
+    }
+
+    public override func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.url, forKey: .url)
+        try super.encode(to: encoder)
+    }
+}
+
+public extension StepMetadata {
+    static func webViewRestWebView(id: String, title: String, url: String, next: PushLinkMetadata? = nil, links: [LinkMetadata] = []) -> WebViewRestWebViewMetadata {
+        WebViewRestWebViewMetadata(
+            id: id,
+            title: title,
+            url: url,
+            next: next,
+            links: links
+        )
+    }
+}
+
+public struct RestWebView: Codable, Identifiable {
+    public let id: String
+}
+
+
+// MARK: - Step support declaration
+public class RestWebViewStep: ObservableStep, BuildableStepWithMetadata {
+    public let properties: WebViewRestWebViewMetadata
+    var configuration: WebViewWebViewMetadata? = nil
+    
+    public required init(properties: WebViewRestWebViewMetadata, session: Session, services: StepServices) {
+        self.properties = properties
+        super.init(identifier: properties.id, session: session, services: services)
+    }
+
+    public override func instantiateViewController() -> StepViewController {
+        MWWebViewController(step: self)
+    }
+}
+
+extension RestWebViewStep: WebStepConfiguration {
+    public var hideNavigation: Bool {
+        configuration?.hideNavigation ?? true
+    }
+    
+    public var hideNavigationBar: Bool {
+        configuration?.hideTopNavigationBar ?? true
+    }
+    
+    public var resolvedUrl: URL? {
+        guard let base = configuration?.url else { return nil }
+        return session.resolve(url: base)
+    }
+    
+    public var sharingEnabled: Bool {
+        configuration?.sharingEnabled ?? false
+    }
+    
+    public var actions: [WebViewWebViewItem]? {
+        configuration?.actions
+    }
+    
+    public func translate(text: String) -> String {
+        services.localizationService.translate(text) ?? text
+    }
+}

--- a/MWWebPlugin/MWWebPlugin/RestWebStep/RestWebViewStep.swift
+++ b/MWWebPlugin/MWWebPlugin/RestWebStep/RestWebViewStep.swift
@@ -129,4 +129,19 @@ extension RestWebViewStep: WebStepConfiguration {
     public func translate(text: String) -> String {
         services.localizationService.translate(text) ?? text
     }
+    
+    public func perform(action: WebViewWebViewItem) async throws -> Bool {
+        guard let method = HTTPMethod(rawValue: action.method) else { return false }
+        guard let url = self.session.resolve(url: action.url) else { return false }
+        
+        let task: URLAsyncTask<Void> = URLAsyncTask<Void>.build(url: url, method: method, session: self.session, parser: { _ in () })
+        try await self.services.perform(task: task, session: self.session)
+        
+        let previousURL = self.configuration?.url
+        if try await self.preloadConfiguration() {
+            return self.configuration?.url != previousURL
+        } else {
+            return false
+        }
+    }
 }

--- a/MWWebPlugin/MWWebPlugin/RestWebStep/RestWebViewStep.swift
+++ b/MWWebPlugin/MWWebPlugin/RestWebStep/RestWebViewStep.swift
@@ -68,7 +68,21 @@ public class RestWebViewStep: ObservableStep, BuildableStepWithMetadata {
 
 extension RestWebViewStep: WebStepConfiguration {
     public func preloadConfiguration() async throws -> Bool {
-        //TODO: Reload configuration
+        let data: Data = try await self.get(path: self.properties.url)
+        guard var baseContent = (try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)) as? [String: Any] else {
+            return false
+        }
+        //To avoid re-creating a model and re-use the static structure
+        //we are copying id/title of the object into the server response
+        if let title = self.title {
+            baseContent["title"] = title
+        }
+        baseContent["id"] = self.identifier
+        baseContent["type"] = self.properties.type
+        
+        let builtData = try JSONSerialization.data(withJSONObject: baseContent, options: .fragmentsAllowed)
+        self.configuration = try JSONDecoder().decode(WebViewWebViewMetadata.self, from: builtData)
+
         return true
     }
     

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
@@ -51,6 +51,11 @@ public class MWWebStep: MWStep, WebStepConfiguration {
     public func translate(text: String) -> String {
         return self.services.localizationService.translate(text) ?? text
     }
+    
+    public func preloadConfiguration() async throws -> Bool {
+        //Configuration is already loaded. So, nothing is done
+        return false
+    }
 }
 
 extension MWWebStep: BuildableStep {

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
@@ -8,23 +8,23 @@
 import Foundation
 import MobileWorkflowCore
 
-public class MWWebStep: MWStep {
+public class MWWebStep: MWStep, WebStepConfiguration {
     
     let url: String
-    let actions: [WebViewWebViewItem]
-    let hideNavigation: Bool
-    let hideNavigationBar: Bool
-    let sharingEnabled: Bool
+    public let actions: [WebViewWebViewItem]?
+    public let hideNavigation: Bool
+    public let hideNavigationBar: Bool
+    public let sharingEnabled: Bool
     let session: Session
     let services: StepServices
     
-    var resolvedUrl: URL? {
+    public var resolvedUrl: URL? {
         self.session.resolve(url: url)
     }
     
     init(identifier: String,
          url: String,
-         actions: [WebViewWebViewItem],
+         actions: [WebViewWebViewItem]?,
          hideNavigation: Bool,
          hideNavigationBar: Bool,
          sharingEnabled: Bool,
@@ -67,11 +67,11 @@ extension MWWebStep: BuildableStep {
         let hideNavigationBar = stepInfo.data.content["hideTopNavigationBar"] as? Bool ?? false
         let sharingEnabled = stepInfo.data.content["sharingEnabled"] as? Bool ?? false
         
-        let actions: [WebViewWebViewItem]
+        let actions: [WebViewWebViewItem]?
         if let storedActions = stepInfo.data.content["actions"] as? [[String: Any]] {
             actions = try storedActions.map({ try WebViewWebViewItem.parse($0) })
         } else {
-            actions = []
+            actions = nil
         }
         
         return MWWebStep(identifier: stepInfo.data.identifier,

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebStep.swift
@@ -56,6 +56,15 @@ public class MWWebStep: MWStep, WebStepConfiguration {
         //Configuration is already loaded. So, nothing is done
         return false
     }
+    
+    public func perform(action: WebViewWebViewItem) async throws -> Bool {
+        guard let method = HTTPMethod(rawValue: action.method) else { return false }
+        guard let url = self.session.resolve(url: action.url) else { return false }
+        
+        let task: URLAsyncTask<Void> = URLAsyncTask<Void>.build(url: url, method: method, session: self.session, parser: { _ in () })
+        try await self.services.perform(task: task, session: self.session)
+        return false
+    }
 }
 
 extension MWWebStep: BuildableStep {

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -128,7 +128,19 @@ public class MWWebViewController: MWStepViewController {
     }
     
     @objc private func performRemoteAction(sender: UIBarButtonItem) {
-        //TODO: Actually perform the action
+        guard let actions = self.webStep.actions, sender.tag < actions.count, sender.tag >= 0 else { return }
+        let action = actions[sender.tag]
+        Task {
+            do {
+                let reloadWebView = try await self.webStep.perform(action: action)
+                self.configureUIElements(animated: false)
+                if reloadWebView {
+                    self.load(showLoading: true)
+                }
+            } catch {
+                await self.show(error)
+            }
+        }
     }
     
     private func configureToolbar() {

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -65,9 +65,8 @@ public class MWWebViewController: MWStepViewController {
         super.viewWillAppear(animated)
         if (!self.hideNavigation) {
             self.navigationController?.setToolbarHidden(false, animated: animated)
-        } else {
-            self.configureNavigationBarActions()
         }
+        self.configureNavigationBarActions()
         if (self.hideNavigationBar) {
             self.navigationController?.setNavigationBarHidden(true, animated: animated)
         }
@@ -106,8 +105,24 @@ public class MWWebViewController: MWStepViewController {
     }
     
     private func configureNavigationBarActions() {
-        let nextButtonToShow = self.hasNextStep() ? self.continueButton : nil
-        self.navigationItem.rightBarButtonItems = [self.cancelButtonItem, self.utilityButtonItem, nextButtonToShow].compactMap { $0 }
+        var items = [UIBarButtonItem?]()
+        if (self.hideNavigationBar) {
+            let nextButtonToShow = self.hasNextStep() ? self.continueButton : nil
+            items += [self.cancelButtonItem, self.utilityButtonItem, nextButtonToShow]
+        }
+        items += self.webStep.actions.mapIndexed(build(tag:action:))
+        self.navigationItem.rightBarButtonItems = items.compactMap { $0 }
+    }
+    
+    private func build(tag: Int, action: WebViewWebViewItem) -> UIBarButtonItem? {
+        guard let icon = UIImage(systemName: action.sfSymbolName) else { return nil }
+        let item = UIBarButtonItem(image: icon, style: .plain, target: self, action: #selector(performRemoteAction(sender:)))
+        item.tag = tag //Tag is used to discover the item later on.
+        return item
+    }
+    
+    @objc private func performRemoteAction(sender: UIBarButtonItem) {
+        //TODO: Actually perform the action
     }
     
     private func configureToolbar() {
@@ -165,6 +180,16 @@ public class MWWebViewController: MWStepViewController {
     
     @IBAction private func continueToNextStep(_ sender: UIBarButtonItem) {
         self.goForward()
+    }
+}
+
+extension Collection {
+    func mapIndexed<T>(_ transform: (Int, Element) -> T) -> [T] {
+        var response = [T]()
+        for (index, element) in self.enumerated() {
+            response.append(transform(index, element))
+        }
+        return response
     }
 }
 

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -28,9 +28,9 @@ public class MWWebViewController: MWStepViewController {
         loadingIndicator.hidesWhenStopped = true
         return loadingIndicator
     }()
-    private var webStep: MWWebStep {
-        guard let webStep = self.mwStep as? MWWebStep else {
-            preconditionFailure("Unexpected step type. Expecting \(String(describing: MWWebStep.self)), got \(String(describing: type(of: self.mwStep)))")
+    private var webStep: WebStepConfiguration {
+        guard let webStep = self.mwStep as? WebStepConfiguration else {
+            preconditionFailure("Unexpected step type. Expecting \(String(describing: WebStepConfiguration.self)), got \(String(describing: type(of: self.mwStep)))")
         }
         return webStep
     }
@@ -110,7 +110,7 @@ public class MWWebViewController: MWStepViewController {
             let nextButtonToShow = self.hasNextStep() ? self.continueButton : nil
             items += [self.cancelButtonItem, self.utilityButtonItem, nextButtonToShow]
         }
-        items += self.webStep.actions.mapIndexed(build(tag:action:))
+        items += self.webStep.actions?.mapIndexed(build(tag:action:)) ?? []
         self.navigationItem.rightBarButtonItems = items.compactMap { $0 }
     }
     

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -65,18 +65,27 @@ public class MWWebViewController: MWStepViewController {
     }
     
     //MARK: Private methods
+    @MainActor
     private func configureUIElements(animated: Bool) {
         if self.webStep.sharingEnabled && self.hideNavigation {
             // show share button on navigation bar when sharing is enabled and toolbar is hidden
             let iconImage = UIImage(systemName: "square.and.arrow.up")
             self.utilityButtonItem = UIBarButtonItem(image: iconImage, style: .plain, target: self, action: #selector(self.shareAction))
         }
-        if (!self.hideNavigation) {
+        if (self.hideNavigation) {
+            self.navigationController?.setToolbarHidden(true, animated: animated)
+        } else {
+            if let navigationBar = self.navigationController?.navigationBar {
+                self.configureNavigationBar(navigationBar)
+            }
             self.navigationController?.setToolbarHidden(false, animated: animated)
         }
         self.configureNavigationBarActions()
         if (self.hideNavigationBar) {
             self.navigationController?.setNavigationBarHidden(true, animated: animated)
+        } else {
+            self.configureToolbar()
+            self.navigationController?.setNavigationBarHidden(false, animated: animated)
         }
     }
     

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -40,6 +40,19 @@ public class MWWebViewController: MWStepViewController {
     private var hideNavigationBar: Bool {
         return self.webStep.hideNavigationBar
     }
+    private lazy var actionLoadingIndicator = {
+        let stateView = UIView()
+        stateView.layer.cornerRadius = 5.0
+        stateView.backgroundColor = UIColor.black.withAlphaComponent(0.8)
+        stateView.translatesAutoresizingMaskIntoConstraints = false
+        
+        let progress = UIActivityIndicatorView(style: .large)
+        progress.color = .white
+        progress.startAnimating()
+        stateView.addPinnedSubview(progress, insets: .init(top: 10.0, leading: 10.0, bottom: 10.0, trailing: 10.0))
+        
+        return stateView
+    }()
     
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -132,15 +145,30 @@ public class MWWebViewController: MWStepViewController {
         let action = actions[sender.tag]
         Task {
             do {
+                self.showActionLoading()
                 let reloadWebView = try await self.webStep.perform(action: action)
                 self.configureUIElements(animated: false)
+                self.hideActionLoading()
                 if reloadWebView {
                     self.load(showLoading: true)
                 }
             } catch {
+                self.hideActionLoading()
                 await self.show(error)
             }
         }
+    }
+    
+    private func showActionLoading() {
+        self.view.addSubview(self.actionLoadingIndicator)
+        NSLayoutConstraint.activate([
+            self.actionLoadingIndicator.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            self.actionLoadingIndicator.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
+        ])
+    }
+    
+    private func hideActionLoading() {
+        self.actionLoadingIndicator.removeFromSuperview()
     }
     
     private func configureToolbar() {

--- a/MWWebPlugin/MWWebPlugin/WebStep/WebStepConfiguration.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/WebStepConfiguration.swift
@@ -13,5 +13,7 @@ public protocol WebStepConfiguration {
     var resolvedUrl: URL? { get }
     var sharingEnabled: Bool { get }
     var actions: [WebViewWebViewItem]? { get }
+    
     func translate(text: String) -> String
+    func preloadConfiguration() async throws -> Bool
 }

--- a/MWWebPlugin/MWWebPlugin/WebStep/WebStepConfiguration.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/WebStepConfiguration.swift
@@ -16,4 +16,5 @@ public protocol WebStepConfiguration {
     
     func translate(text: String) -> String
     func preloadConfiguration() async throws -> Bool
+    func perform(action: WebViewWebViewItem) async throws -> Bool
 }

--- a/MWWebPlugin/MWWebPlugin/WebStep/WebStepConfiguration.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/WebStepConfiguration.swift
@@ -1,0 +1,17 @@
+//
+//  WebStepConfiguration.swift
+//  MWWebPlugin
+//
+//  Created by Igor Ferreira on 2/6/23.
+//
+
+import Foundation
+
+public protocol WebStepConfiguration {
+    var hideNavigation: Bool { get }
+    var hideNavigationBar: Bool { get }
+    var resolvedUrl: URL? { get }
+    var sharingEnabled: Bool { get }
+    var actions: [WebViewWebViewItem]? { get }
+    func translate(text: String) -> String
+}


### PR DESCRIPTION
### Task

[[iOS] [Android] [Rails] Allow users to favourite content](https://3.basecamp.com/5245563/buckets/26112855/todos/6171847580)

### Feature/Issue

1. Allow the user to configure actions to be displayed in the navigation bar (if the user also hides the top navigation bar, these actions are not visible)
2. Create a new step called Rest WebView that can be used to remotely load the step configuration

### Implementation

1. Create a `WebStepConfiguration` protocol so both Static and Rest steps can use the same view controller
2. Created a method `preloadConfiguration` to be used by the ViewController to call the network URL (if necessary)
3. Created behaviour to perform remote actions

### Demonstration

https://github.com/FutureWorkshops/MWWebPlugin-iOS/assets/2117340/8844ca0c-57f5-4528-826e-421ef310c763


