### PR TITLE
[iOS] Bug relating to WebView plugin

### DIFF
--- a/MWWebPlugin.podspec
+++ b/MWWebPlugin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name                  = 'MWWebPlugin'
-    s.version               = '0.4.0'
+    s.version               = '0.4.1'
     s.summary               = 'WebView plugin for MobileWorkflow on iOS.'
     s.description           = <<-DESC
     WebView plugin for MobileWorkflow on iOS, containg WebView related steps:

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -13,7 +13,10 @@ import UIKit
 public class MWWebViewController: MWStepViewController {
     
     public override var titleMode: StepViewControllerTitleMode { .smallTitle }
-    lazy var continueButton = UIBarButtonItem(title: self.webStep.translate(text: "Next"), style: .done, target: self, action: #selector(self.continueToNextStep(_:)))
+    lazy var continueButton: UIBarButtonItem = {
+        let title = self.webStep.translate(text: self.isLastStepOnFlow ? "Done" : "Next")
+        return UIBarButtonItem(title: title, style: .done, target: self, action: #selector(self.continueToNextStep(_:)))
+    }()
     
     private lazy var webView = {
         let webView = WKWebView()

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -200,6 +200,15 @@ public class MWWebViewController: MWStepViewController {
         self.webView.load(request)
     }
     
+    private func loadDidComplete() async {
+        await self.hideLoading()
+    }
+    
+    private func loadDidFail(_ error: Error) async {
+        await self.hideLoading()
+        await self.show(error)
+    }
+    
     @MainActor
     private func showUnableToResolveURLError() {
         self.hideLoading()
@@ -267,21 +276,15 @@ extension MWWebViewController: WKUIDelegate {
 
 extension MWWebViewController: WKNavigationDelegate {
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        Task { await self.hideLoading() }
+        Task { await self.loadDidComplete() }
     }
     
     public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        Task {
-            await self.hideLoading()
-            await self.show(error)
-        }
+        Task { await self.loadDidFail(error) }
     }
     
     public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        Task {
-            await self.hideLoading()
-            await self.show(error)
-        }
+        Task { await self.loadDidFail(error) }
     }
 }
 

--- a/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
+++ b/MWWebPlugin/MWWebPlugin/WebStep/MWWebViewController.swift
@@ -276,6 +276,13 @@ extension MWWebViewController: WKNavigationDelegate {
             await self.show(error)
         }
     }
+    
+    public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        Task {
+            await self.hideLoading()
+            await self.show(error)
+        }
+    }
 }
 
 extension MWWebViewController {


### PR DESCRIPTION
### Task

[[iOS] Bug relating to WebView plugin](https://3.basecamp.com/5245563/buckets/26145695/todos/6266005564/edit?replace=true)

### Feature/Issue

This PR fixes an issue that was identified while investigating the main issue in the ticket, this being that provisional loading errors aren't handled and therefore when received, the 'loading' state persists indefinitely.

### Implementation

Added delegate implementation for `webView(_:didFailProvisionalNavigation:withError:)` whose implementation matches the existing one for `webView(_:didFail:withError:)`, i.e. it hides the loading state and shows the error as an alert.

### Notes

In addition to the mentioned fix, and to align with common behaviour elsewhere, there is now logic to show the barButtonItem `continueButton` title 'Done' instead 'Next' if the step has no subsequent steps, i.e. tapping will dismiss the modal step flow. The button will continue to be hidden if the step is at the end of a non-modal flow.